### PR TITLE
[iam] introduce iam_compartmen_id 

### DIFF
--- a/module-iam.tf
+++ b/module-iam.tf
@@ -55,7 +55,7 @@ module "iam" {
   source                       = "./modules/iam"
   compartment_id               = local.compartment_id
   state_id                     = local.state_id
-  tenancy_id                   = local.tenancy_id
+  tenancy_id                   = local.iam_compartment_id
   cluster_id                   = local.cluster_id
   create_iam_resources         = var.create_iam_resources
   create_iam_autoscaler_policy = local.create_iam_autoscaler_policy

--- a/variables-iam.tf
+++ b/variables-iam.tf
@@ -3,6 +3,7 @@
 
 locals {
   tenancy_id            = coalesce(var.tenancy_id, var.tenancy_ocid, "unknown")
+  iam_compartment_id    = coalesce(var.iam_compartment_id, local.tenancy_id)
   compartment_id        = coalesce(var.compartment_id, var.compartment_ocid, var.tenancy_id)
   worker_compartment_id = coalesce(var.worker_compartment_id, var.compartment_id)
   user_id               = var.user_id != "" ? var.user_id : var.current_user_ocid
@@ -47,6 +48,12 @@ variable "tenancy_id" {
 variable "tenancy_ocid" {
   default     = null
   description = "A tenancy OCID automatically populated by Resource Manager."
+  type        = string
+}
+
+variable "iam_compartment_id" {
+  default     = null
+  description = "The comparment id of the parent comparment in which to create the IAM resources."
   type        = string
 }
 


### PR DESCRIPTION
which define the top parent compartment for IAM resources when not at tenancy level.